### PR TITLE
Colorize hash keys looking like Rails functions correctly.

### DIFF
--- a/Syntaxes/Ruby on Rails.plist
+++ b/Syntaxes/Ruby on Rails.plist
@@ -7,7 +7,7 @@
 		<string>rb</string>
 		<string>rxml</string>
 		<string>builder</string>
-                <string>Gemfile</string>
+		<string>Gemfile</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~R</string>
@@ -259,25 +259,25 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(before_filter|skip_before_filter|skip_after_filter|after_filter|around_filter|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|model|service|observer|serialize|scaffold|verify|hide_action)\b</string>
+			<string>\b(before_filter|skip_before_filter|skip_after_filter|after_filter|around_filter|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|model|service|observer|serialize|scaffold|verify|hide_action)\b(?!:)</string>
 			<key>name</key>
 			<string>support.function.actionpack.rails</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(check_box|content_for|error_messages_for|form_for|fields_for|file_field|hidden_field|image_submit_tag|label|link_to|password_field|radio_button|submit|text_field|text_area)\b</string>
+			<string>\b(check_box|content_for|error_messages_for|form_for|fields_for|file_field|hidden_field|image_submit_tag|label|link_to|password_field|radio_button|submit|text_field|text_area)\b(?!:)</string>
 			<key>name</key>
 			<string>support.function.viewhelpers.rails</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|validate|validates|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|attr_protected|attr_accessible|attr_readonly|accepts_nested_attributes_for|default_scope|scope)\b</string>
+			<string>\b(after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|validate|validates|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|attr_protected|attr_accessible|attr_readonly|accepts_nested_attributes_for|default_scope|scope)\b(?!:)</string>
 			<key>name</key>
 			<string>support.function.activerecord.rails</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(alias_method_chain|alias_attribute|delegate|cattr_accessor|mattr_accessor|returning|memoize)\b</string>
+			<string>\b(alias_method_chain|alias_attribute|delegate|cattr_accessor|mattr_accessor|returning|memoize)\b(?!:)</string>
 			<key>name</key>
 			<string>support.function.activesupport.rails</string>
 		</dict>


### PR DESCRIPTION
Using 1.9 syntax, in `{ label: "foo" }` the key was colorized as Rails function instead of symbol.

This does not happen using the old syntax `{ :label => "foo" }` – but I don’t really know why … Maybe there is a simpler solution instead of changing the regexps for 1.9?
