### PR TITLE
Add snippet for module "concerns"

### DIFF
--- a/Snippets/Module concerns.tmSnippet
+++ b/Snippets/Module concerns.tmSnippet
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>module ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+  extend ActiveSupport::Concern
+
+  included do
+    $2
+  end
+
+  module ClassMethods
+    $3
+  end
+
+  $4
+  
+end
+</string>
+	<key>name</key>
+	<string>Module (concerns)</string>
+	<key>scope</key>
+	<string>source.ruby</string>
+	<key>tabTrigger</key>
+	<string>mod</string>
+	<key>uuid</key>
+	<string>AD41240F-54BF-4FE5-AB6E-E82AB9363B23</string>
+</dict>
+</plist>


### PR DESCRIPTION
Added a snippet to generate boilerplate for "Module Concerns" which is part of rails 4.1

Link [introducing concerns](http://signalvnoise.com/posts/3372-put-chubby-models-on-a-diet-with-concerns) on the 37 signals blog
