### PR TITLE
Fix broken jump_to_method_definition

### DIFF
--- a/Support/bin/jump_to_method_definition.rb
+++ b/Support/bin/jump_to_method_definition.rb
@@ -10,10 +10,10 @@ class FindMethod
   
   def initialize(term, filepath = RailsPath.new)
     @term = term
-    @term = @term + $1 if TextMate.current_line.match(Regexp.new(Regexp.escape(@term) + '(!|\?)'))
+    @term = @term + $1 if TextMate.selected_text.match(Regexp.new(Regexp.escape(@term) + '(!|\?)'))
     @found_methods = []
     @filepath = filepath
-    @root = RailsPath.new.rails_root || TextMate.directory
+    @root = RailsPath.new.rails_root || TextMate.project_directory
     self.find
     self.render_results
   end


### PR DESCRIPTION
Currently, this feature is entirely broken. With this change, the feature works again just so long as you've selected the thing you want to jump to.
