### PR TITLE
Fix "Jump to Method Definition"

### DIFF
--- a/Support/bin/jump_to_method_definition.rb
+++ b/Support/bin/jump_to_method_definition.rb
@@ -2,7 +2,6 @@
 
 require 'rails_bundle_tools'
 require 'fileutils'
-require 'rubygems'
 require "#{ENV['TM_SUPPORT_PATH']}/lib/tm/htmloutput"
 
 class FindMethod
@@ -69,8 +68,12 @@ class FindMethod
   end
 
   def find_in_gems(match_string)
-    Gem.latest_load_paths.each do |directory|
-      find_in_directory(directory, match_string)
+    paths = `cd "#{ENV['TM_PROJECT_DIRECTORY']}" && bundle show --paths`
+    paths.each_line do |line|
+      directory = line.strip
+      if File.directory?(directory)
+        find_in_directory(directory, match_string)
+      end
     end
   end
 


### PR DESCRIPTION
This command fails because of the missing "rubygems" library for the custom Ruby 1.8 interpreter of TextMate 2. The only thing its used for is finding the paths of all installed gems. This makes no sense nowadays anyway, as every supported Rails version requires Bundler, which in turn can list only the gems used in a Rails project.

Shelling out and using `bundle show --paths` restores the functionality of this command, adds no additional dependencies and, needing to search fewer directories, is quicker too.

Fixes #23
