### PR TITLE
add *_action methods

### DIFF
--- a/Syntaxes/Ruby on Rails.plist
+++ b/Syntaxes/Ruby on Rails.plist
@@ -259,7 +259,15 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(before_filter|skip_before_filter|skip_after_filter|after_filter|skip_around_filter|around_filter|skip_filter|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|model|service|observer|serialize|scaffold|verify|hide_action)\b(?!:)</string>
+			<string>\b(after_action|append_after_action|append_around_action|append_before_action|around_action|before_action|prepend_after_action|prepend_around_action|prepend_before_action|skip_after_action|skip_around_action|skip_before_action|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|model|service|observer|serialize|scaffold|verify|hide_action)\b(?!:)</string>
+			<key>name</key>
+			<string>support.function.actionpack.rails</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>These are deprecated since Rails 5, most *_filter methods are replaced by *_action methods.</string>
+			<key>match</key>
+			<string>\b(before_filter|skip_before_filter|skip_after_filter|after_filter|skip_around_filter|around_filter|skip_filter)\b(?!:)</string>
 			<key>name</key>
 			<string>support.function.actionpack.rails</string>
 		</dict>


### PR DESCRIPTION
Since Rails 5 the *_filter methods are deprecated, and have been replaced by *_action methods.

I've places the old methods in a separate `<dict>`, but this might as well be the other way around; the new methods in a separate `<dict>`.

Not even sure if too dictionaries with the same name are allowed/supported?
