### PR TITLE
Fix partially missing syntax highlighting in schema.rb files

### DIFF
--- a/Syntaxes/Ruby on Rails.plist
+++ b/Syntaxes/Ruby on Rails.plist
@@ -213,6 +213,10 @@
 						</dict>
 					</array>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>source.ruby</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>


### PR DESCRIPTION
This was caused by the `meta.rails.schema` scope, which was added in e229357 to include table names in the symbol list for schema.rb files. However, this scope includes `source.ruby` only for within `create_table …` blocks, so everything outside these blocks did not get any syntax highlighting. (Nowadays it’s quite likely that schema.rb contains additional content like `add_foreign_key` statements and such.)

Screenshot demonstrating the missing syntax highlighting:
![bildschirmfoto 2017-09-06 um 20 47 33](https://user-images.githubusercontent.com/244158/30128956-b3ffc868-9344-11e7-9339-f000436c901e.png)
