### PR TITLE
Use api.rubyonrails.org instead of apidock.com

### DIFF
--- a/Commands/Documentation for Word.tmCommand
+++ b/Commands/Documentation for Word.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/usr/bin/env ruby18
-url = "http://apidock.com/rails/search/quick?query=" + ENV['TM_CURRENT_WORD']
+url = "http://api.rubyonrails.org/?q=" + ENV['TM_CURRENT_WORD']
 puts "&lt;meta http-equiv='Refresh' content='0;URL=#{url}'&gt;"
 </string>
 	<key>fallbackInput</key>


### PR DESCRIPTION
Updates "Documentation for Word" command.

Apidock is outdated, api.rubyonrails.org is the way to go: https://github.com/rails/rails/issues/27633